### PR TITLE
feat: Added support as a GitHub Action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3-alpine
+
+WORKDIR /opt/workspace
+
+COPY converter.py /opt/workspace/converter.py
+COPY templates /opt/workspace/templates/
+
+RUN pip install requests
+
+ENV TWITCH_CLIENT_ID=""
+ENV TWITCH_TEAMS_NAME=""
+
+CMD cd /opt/workspace && python converter.py && cp output.md $GITHUB_WORKSPACE/output.md

--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@
 
 ## Configuration
 
-Open `converter.py` and fill in the required values for the properties `TWITCH_CLIENT_ID` and `TWITCH_TEAMS_NAME`.
+Set the environment variables `TWITCH_CLIENT_ID` and `TWITCH_TEAMS_NAME` set before running.
+
+You can set them at runtime like so:
+
+```
+TWITCH_CLIENT_ID="foo" TWITCH_TEAMS_NAME="bar" python converter.py
+```
+
 To change the templates, have a look at the folder `templates/`.
 
 ## Run
@@ -29,6 +36,22 @@ Location: twitch-teams-to-markdown-converter/output.md
 <a href="example.png"><img src="example.png" width="500" /></a>
 
 See [example](example.md).
+
+## GitHub Action
+
+You can use this script as well as a GitHub Action. With such, you need set the environment variables as described earlier.
+
+Here's an example usage:
+
+```yaml
+steps:
+  - uses: tscholze/python-twitch-teams-to-markdown-converter@master
+    env:
+      TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
+      TWITCH_TEAMS_NAME: ${{ secrets.TWITCH_TEAMS_NAME }}
+```
+
+It will generate the output.md file into your `$GITHUB_WORKSPACE` directory which is where your code is checked out to in a normal workflow run.
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,5 @@
+name: Twitch Team to Markdown Converter
+description: Generate a table based on a Twitch team.
+runs:
+  using: "docker"
+  image: "Dockerfile"

--- a/converter.py
+++ b/converter.py
@@ -4,10 +4,10 @@ import datetime
 
 
 # Twitch API client id (https://dev.twitch.tv/console/apps)
-TWITCH_CLIENT_ID = "<KEY>"
+TWITCH_CLIENT_ID = os.environ['TWITCH_CLIENT_ID']
 
 # Name of the Twitch team
-TWITCH_TEAMS_NAME = "<NAME>"
+TWITCH_TEAMS_NAME = os.environ['TWITCH_TEAMS_NAME']
 
 # Computed API teams endpoint url
 TWITCH_TEAMS_ENDPOINT_URL = "https://api.twitch.tv/kraken/teams/" + TWITCH_TEAMS_NAME


### PR DESCRIPTION
Closes #1 

This adds support to run as a GitHub Action. The code for the action can be found between the Dockerfile and the action.yml file.

The one thing I changed in the code was swapped the static strings for the twitch client id and team name to environment variables.

I added some docs on how to use the action in the Readme as well as updated the configuration section about the change to environment variables.